### PR TITLE
Fix SSLServer#accept failures causing accept loop to exit.

### DIFF
--- a/lib/io/endpoint/ssl_endpoint.rb
+++ b/lib/io/endpoint/ssl_endpoint.rb
@@ -10,6 +10,14 @@ require 'openssl'
 
 module OpenSSL
 	module SSL
+		class SSLSocket
+			unless method_defined?(:start)
+				def start
+					self.accept
+				end
+			end
+		end
+		
 		module SocketForwarder
 			unless method_defined?(:close_on_exec=)
 				def close_on_exec=(value)

--- a/lib/io/endpoint/ssl_endpoint.rb
+++ b/lib/io/endpoint/ssl_endpoint.rb
@@ -113,7 +113,9 @@ module IO::Endpoint
 		end
 		
 		def make_server(io)
-			::OpenSSL::SSL::SSLServer.new(io, self.context)
+			::OpenSSL::SSL::SSLServer.new(io, self.context).tap do |server|
+				server.start_immediately = false
+			end
 		end
 		
 		def make_socket(io)

--- a/lib/io/endpoint/wrapper.rb
+++ b/lib/io/endpoint/wrapper.rb
@@ -183,7 +183,7 @@ module IO::Endpoint
 			::Thread.new(&block)
 		end
 	end
-	 
+	
 	class FiberWrapper < Wrapper
 		def async(&block)
 			::Fiber.schedule(&block)

--- a/lib/io/endpoint/wrapper.rb
+++ b/lib/io/endpoint/wrapper.rb
@@ -165,14 +165,17 @@ module IO::Endpoint
 				end
 				
 				async do
-					# Maybe we can expose this back to the endpoint?
-					socket.accept if socket.is_a?(::OpenSSL::SSL::SSLSocket)
+					# Some sockets, notably SSL sockets, need application level negotiation before they are ready:
+					if socket.respond_to?(:start)
+						begin
+							socket.start
+						rescue
+							socket.close
+							raise
+						end
+					end
 					
 					yield socket, address
-				rescue => error
-					socket.close
-					
-					raise
 				end
 			end
 		end

--- a/lib/io/endpoint/wrapper.rb
+++ b/lib/io/endpoint/wrapper.rb
@@ -166,7 +166,7 @@ module IO::Endpoint
 				
 				async do
 					# Maybe we can expose this back to the endpoint?
-					socket.accept if socket.respond_to?(:accept)
+					socket.accept if socket.is_a?(::OpenSSL::SSL::SSLSocket)
 					
 					yield socket, address
 				rescue => error

--- a/lib/io/endpoint/wrapper.rb
+++ b/lib/io/endpoint/wrapper.rb
@@ -165,7 +165,14 @@ module IO::Endpoint
 				end
 				
 				async do
+					# Maybe we can expose this back to the endpoint?
+					socket.accept if socket.respond_to?(:accept)
+					
 					yield socket, address
+				rescue => error
+					socket.close
+					
+					raise
 				end
 			end
 		end
@@ -176,7 +183,7 @@ module IO::Endpoint
 			::Thread.new(&block)
 		end
 	end
-	
+	 
 	class FiberWrapper < Wrapper
 		def async(&block)
 			::Fiber.schedule(&block)


### PR DESCRIPTION
I've observed failures in production in falcon virtual where the proxy stops responding. I believe this is the root cause of the problem - server.accept is failing and (1) killing the accept loop or (2) hanging.

(1) will cause the process to exit and restart, but (2) will cause the proxy to stop accepting new connections which is far more problematic.

This is a regression on `io-endopint`, as `Async::IO::Endpoint` implemented this a little differently.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
