### PR TITLE
`IO::Endpoint::Wrapper#bind` always calls `listen` and handles `EOPNOTSUPP`, but in some environments, the error is translated to/propagated as EACCES

### DIFF
--- a/lib/io/endpoint/wrapper.rb
+++ b/lib/io/endpoint/wrapper.rb
@@ -157,6 +157,13 @@ module IO::Endpoint
 						socket.listen(backlog)
 					rescue Errno::EOPNOTSUPP
 						# Ignore.
+					rescue Errno::EACCES
+						# Unfortunately, in some environments, the error gets translated to "permission denied" instead.
+						if local_address.socktype == ServerSocket::SOCK_DGRAM
+							# Ignore
+						else
+							raise
+						end
 					end
 				end
 			rescue


### PR DESCRIPTION
`IO::Endpoint::Wrapper.bind` always does bind and listen, and handles `Errno::EOPNOTSUPP`, for example for UDP sockets, for which `listen` is not applicable. However, in some environments, such as in a container, the error may be mapped to `EACCES`, which as is, is not handled, basically causing the upper level program (e.g. a `RubyDNS` server) to crash.

This patch ignores `Errno::EACCES` if it was a UDP socket, since the `listen` call was meaningless in the first place.

Example C program to compile and run in a container:

```c
// hi.c

#include <stdlib.h>
#include <stdio.h>
#include <string.h>
#include <unistd.h>
#include <arpa/inet.h>

#define PORT 5300
#define BACKLOG 4096

int main(void) {
        int sockfd;
        struct sockaddr_in addr;

        sockfd = socket(AF_INET, SOCK_DGRAM, 0);
        if (sockfd < 0) {
                perror("socket");
                exit(EXIT_FAILURE);
        }

        memset(&addr, 0, sizeof(addr));
        addr.sin_family = AF_INET;
        addr.sin_addr.s_addr = htonl(INADDR_ANY);
        addr.sin_port = htons(PORT);

        if (bind(sockfd, (struct sockaddr*) &addr, sizeof(addr)) < 0) {
                perror("bind");
                close(sockfd);
                exit(EXIT_FAILURE);
        }

        if (listen(sockfd, BACKLOG) < 0) {
                perror("listen");
                close(sockfd);
                exit(EXIT_FAILURE);
        }

        printf("Cool!\n");
        return 0;
}
```

```bash
podman run --rm -it --volume .:/root:z fedora:42 bash
dnf install gcc
gcc hi.c
./a.out
```

On my host system (Fedora 42), it prints "listen: Operation not supported" (`EOPNOTSUPP`) as already handled, but in both a `fedora:42` or `ubuntu:25.10` container, it prints "listen: Permission denied" (`EACCES`).


## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
