### PR TITLE
Add EHOSTUNREACH to retry conditions

### DIFF
--- a/lib/io/endpoint/host_endpoint.rb
+++ b/lib/io/endpoint/host_endpoint.rb
@@ -44,7 +44,7 @@ module IO::Endpoint
 			Addrinfo.foreach(*@specification) do |address|
 				begin
 					socket = wrapper.connect(address, **@options)
-				rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::EAGAIN => last_error
+				rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Errno::EAGAIN => last_error
 					# Try again unless if possible, otherwise raise...
 				else
 					return socket unless block_given?


### PR DESCRIPTION
Adds the `Errno::EHOSTUNREACH` to the retry conditions when trying to connect to a host endpoint. I'm not sure, under which conditions this specific errno is thrown, however I've experienced it when playing around with the `async-dns` wikipedia example.

Fixes #18.

## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
