### PR TITLE
Add exclusive UNIX endpoint ownership

### DIFF
--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -24,6 +24,7 @@ The library centers around the {ruby IO::Endpoint::Generic} class, which represe
 - {ruby IO::Endpoint::HostEndpoint} - Resolves hostnames to addresses (e.g., "localhost:8080")
 - {ruby IO::Endpoint::AddressEndpoint} - Works with specific network addresses
 - {ruby IO::Endpoint::UNIXEndpoint} - Handles UNIX domain sockets
+- {ruby IO::Endpoint::ExclusiveUNIXEndpoint} - Owns and cleans up UNIX domain socket paths
 - {ruby IO::Endpoint::SSLEndpoint} - Wraps endpoints with SSL/TLS encryption
 - {ruby IO::Endpoint::CompositeEndpoint} - Combines multiple endpoints
 
@@ -92,6 +93,30 @@ endpoint.bind do |server|
 	end
 end
 ```
+
+When a bound endpoint exclusively owns its socket path, use `IO::Endpoint.exclusive_unix`. Closing the bound endpoint removes the socket path. An adjacent lock file serializes ownership and allows a new process to recover a stale socket after the previous owner crashes:
+
+```ruby
+endpoint = IO::Endpoint.exclusive_unix("/tmp/myapp.sock")
+bound_endpoint = endpoint.bound
+
+begin
+	# Run a server using bound_endpoint.
+ensure
+	bound_endpoint.close
+end
+```
+
+Exclusive ownership applies to sockets created with `#bind` or `#bound`. An orderly close removes both the socket and lock paths. After a crash, the lock file can remain and is reused by subsequent owners.
+
+To generate a unique socket path for a worker, pass an existing directory and a prefix using `unique:`. The concrete path is generated immediately and is available through `#path`, so it can be registered with a service discovery mechanism before the worker starts serving:
+
+```ruby
+endpoint = IO::Endpoint.exclusive_unix("/tmp/workers", unique: "worker")
+endpoint.path # => "/tmp/workers/worker-12345-a4c091b25e2f6408.ipc"
+```
+
+The directory must already exist. Generated paths include the process identifier and random entropy. Crashed processes can leave stale socket and lock paths, so consumers should use stable names, tolerate failed connections, or obtain the viable paths from a service discovery mechanism.
 
 ### Using SSL/TLS
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -24,6 +24,7 @@ The library centers around the {ruby IO::Endpoint::Generic} class, which represe
 - {ruby IO::Endpoint::HostEndpoint} - Resolves hostnames to addresses (e.g., "localhost:8080")
 - {ruby IO::Endpoint::AddressEndpoint} - Works with specific network addresses
 - {ruby IO::Endpoint::UNIXEndpoint} - Handles UNIX domain sockets
+- {ruby IO::Endpoint::ExclusiveUNIXEndpoint} - Owns and cleans up UNIX domain socket paths
 - {ruby IO::Endpoint::SSLEndpoint} - Wraps endpoints with SSL/TLS encryption
 - {ruby IO::Endpoint::CompositeEndpoint} - Combines multiple endpoints
 
@@ -92,6 +93,30 @@ endpoint.bind do |server|
 	end
 end
 ```
+
+When a bound endpoint exclusively owns its socket path, use `IO::Endpoint.exclusive_unix`. Closing the bound endpoint removes the socket path. An adjacent lock file serializes ownership and allows a new process to recover a stale socket after the previous owner crashes:
+
+```ruby
+endpoint = IO::Endpoint.exclusive_unix("/tmp/myapp.sock")
+bound_endpoint = endpoint.bound
+
+begin
+	# Run a server using bound_endpoint.
+ensure
+	bound_endpoint.close
+end
+```
+
+Exclusive ownership applies to sockets created with `#bind` or `#bound`. An orderly close removes both the socket and lock paths. After a crash, the lock file can remain and is reused by subsequent owners.
+
+To generate a unique socket path for a worker, pass an existing directory and a prefix using `unique:`. The concrete path is generated immediately and is available through `#path`, so it can be registered with a service discovery mechanism before the worker starts serving:
+
+```ruby
+endpoint = IO::Endpoint.exclusive_unix("/tmp/workers", unique: "worker")
+endpoint.path # => "/tmp/workers/worker-12345-a4c091b25e2f6408.ipc"
+```
+
+The directory must already exist. Generated paths include the process identifier and random entropy. Crashed processes can leave stale socket and lock paths, so consumers should use stable names, tolerate failed connections, or obtain the viable paths from a service discovery mechanism.
 
 ### Using SSL/TLS
 

--- a/lib/io/endpoint/exclusive_unix_endpoint.rb
+++ b/lib/io/endpoint/exclusive_unix_endpoint.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023-2026, by Samuel Williams.
+# Copyright, 2026, by Delton Ding.
+
+require "securerandom"
+
+require_relative "unix_endpoint"
+
+module IO::Endpoint
+	# Represents an exclusively owned endpoint for a UNIX domain socket.
+	class ExclusiveUNIXEndpoint < UNIXEndpoint
+		# Represents the ownership lifecycle for an exclusive UNIX socket.
+		class Ownership
+			# Initialize an exclusive ownership lifecycle.
+			# @parameter lock [File] The exclusive ownership lock.
+			# @parameter paths [Array(String)] The owned filesystem paths.
+			def initialize(lock, paths)
+				@lock = lock
+				@released = false
+				@lock_identity = [lock.path, lock.stat]
+				
+				@path_identities = paths.filter_map do |path|
+					[path, File.lstat(path)]
+				rescue Errno::ENOENT
+					# The path was removed before ownership could be recorded:
+				end
+			end
+			
+			# Set whether the ownership lock should close on exec.
+			# @parameter value [Boolean] Whether to close the lock on exec.
+			def close_on_exec=(value)
+				@lock.close_on_exec = value
+			end
+			
+			# Release ownership and remove the exclusively owned paths.
+			def release
+				return if @released
+				@released = true
+				
+				@path_identities.each do |path_identity|
+					unlink_if_owned(*path_identity)
+				end
+				
+				unlink_if_owned(*@lock_identity)
+			ensure
+				@lock.close unless @lock.closed?
+			end
+			
+			# Unlink a path if it still refers to the owned filesystem entry.
+			private def unlink_if_owned(path, identity)
+				current = File.lstat(path)
+				
+				if current.dev == identity.dev && current.ino == identity.ino
+					File.unlink(path)
+				end
+			rescue Errno::ENOENT
+				# The path was already removed:
+			end
+		end
+		
+		# Adds exclusive ownership behavior to a bound UNIX socket.
+		module OwnedSocket
+			# Set whether the socket and its ownership lock should close on exec.
+			# @parameter value [Boolean] Whether to close on exec.
+			def close_on_exec=(value)
+				@exclusive_ownership.close_on_exec = value
+				super
+			end
+			
+			# Close the socket and release its filesystem paths.
+			def close
+				super
+			ensure
+				@exclusive_ownership.release
+			end
+		end
+		
+		# Bind and exclusively own the UNIX socket paths.
+		# @yields {|socket| ...} If a block is given, yields the bound socket.
+		# 	@parameter socket [Socket] The bound socket.
+		# @returns [Array(Socket)] The bound socket.
+		# @raises [Errno::EADDRINUSE] If another exclusive endpoint owns the path.
+		def bind(wrapper = self.wrapper, &block)
+			lock = acquire_exclusive_lock
+			
+			begin
+				# The ownership lifecycle must be attached before a bind block can run:
+				result = super(wrapper, &nil)
+				ownership = Ownership.new(lock, paths)
+				
+				result.each do |socket|
+					socket.instance_variable_set(:@exclusive_ownership, ownership)
+					socket.extend(OwnedSocket)
+				end
+				
+				lock = nil
+				
+				if block
+					return result.map do |socket|
+						wrapper.schedule do
+							begin
+								block.call(socket)
+							ensure
+								socket.close
+							end
+						end
+					end
+				else
+					return result
+				end
+			rescue
+				if ownership || lock
+					result&.each(&:close)
+					Ownership.new(lock, []).release if lock && !lock.closed?
+				end
+				
+				raise
+			end
+		end
+		
+		# Acquire the lock which serializes exclusive ownership and stale path recovery.
+		# @returns [File] The locked file.
+		# @raises [Errno::EADDRINUSE] If another exclusive endpoint owns the path.
+		private def acquire_exclusive_lock
+			lock_path = @address.unix_path + ".lock"
+			lock = File.open(lock_path, File::RDWR | File::CREAT, 0o600)
+			
+			unless lock.flock(File::LOCK_EX | File::LOCK_NB)
+				lock.close
+				raise Errno::EADDRINUSE, @path
+			end
+			
+			return lock
+		rescue
+			lock&.close unless lock&.closed?
+			raise
+		end
+	end
+	
+	# @parameter path [String]
+	# @parameter type Socket type
+	# @parameter unique [String | Nil] An optional prefix for a unique socket path generated within `path`.
+	# @parameter options keyword arguments passed through to {ExclusiveUNIXEndpoint#initialize}
+	#
+	# @returns [ExclusiveUNIXEndpoint]
+	def self.exclusive_unix(path = "", type = ::Socket::SOCK_STREAM, unique: nil, **options)
+		unless unique.nil?
+			unless unique.is_a?(String) && !unique.empty? && File.basename(unique) == unique && unique != "." && unique != ".."
+				raise ArgumentError, "Unique prefix must be a non-empty basename!"
+			end
+			
+			unless File.stat(path).directory?
+				raise Errno::ENOTDIR, path
+			end
+			
+			path = File.join(path, "#{unique}-#{Process.pid}-#{SecureRandom.hex(8)}.ipc")
+		end
+		
+		ExclusiveUNIXEndpoint.new(path, type, **options)
+	end
+end

--- a/lib/io/endpoint/unix_endpoint.rb
+++ b/lib/io/endpoint/unix_endpoint.rb
@@ -9,9 +9,10 @@ require "fileutils"
 require "tmpdir"
 
 require_relative "address_endpoint"
+require_relative "bound_endpoint"
 
 module IO::Endpoint
-	# This class doesn't exert ownership over the specified unix socket and ensures exclusive access by using `flock` where possible.
+	# Represents an endpoint for a UNIX domain socket.
 	class UNIXEndpoint < AddressEndpoint
 		# Compute a stable temporary UNIX socket path for an overlong path.
 		# @parameter path [String] The original (possibly overlong) path.
@@ -64,6 +65,18 @@ module IO::Endpoint
 			@path
 		end
 		
+		# The filesystem paths used by this endpoint.
+		# @returns [Array(String)] The configured and actual UNIX socket paths.
+		def paths
+			target_path = @address.unix_path
+			
+			if @path == target_path
+				[@path]
+			else
+				[@path, target_path]
+			end
+		end
+		
 		# Check if a symlink is used for this endpoint.
 		#
 		# A symlink is created when the original path exceeds the system's maximum UNIX socket path length and a shorter temporary path is used for the actual socket.
@@ -83,6 +96,8 @@ module IO::Endpoint
 			return false
 		rescue Errno::ENOENT
 			return false
+		rescue Errno::ENOTSOCK
+			return false
 		end
 		
 		# Bind the UNIX socket, handling stale socket files.
@@ -96,12 +111,17 @@ module IO::Endpoint
 			return result
 		rescue Errno::EADDRINUSE
 			# If you encounter EADDRINUSE from `bind()`, you can check if the socket is actually accepting connections by attempting to `connect()` to it. If the socket is still bound by an active process, the connection will succeed. Otherwise, it should be safe to `unlink()` the path and try again.
-			if !bound?
+			if !bound? && stale_socket?
 				unlink_stale_paths!
 				retry
 			else
 				raise
 			end
+		end
+		
+		# Whether the actual path refers to a stale UNIX socket.
+		private def stale_socket?
+			File.socket?(@address.unix_path)
 		end
 		
 		# Read a symlink, returning nil if the file does not exist.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,11 @@
 # Releases
 
+## Unreleased
+
+  - Add `IO::Endpoint.exclusive_unix` for bound UNIX endpoints which own and remove their socket paths while supporting stale socket recovery.
+  - Add the `unique:` option for generating worker socket paths within an existing directory.
+  - Avoid replacing unrelated filesystem entries when recovering stale UNIX sockets.
+
 ## v0.17.2
 
   - When the unix path is bigger than what can fit into `struct sockaddr_un`, a shorter temporary path will be used instead and a symlink created at the original path.

--- a/test/io/endpoint/unix_endpoint.rb
+++ b/test/io/endpoint/unix_endpoint.rb
@@ -346,6 +346,9 @@ describe IO::Endpoint do
 			end
 			
 			it "requires a valid prefix and an existing directory" do
+				file_path = File.join(temporary_directory, "file")
+				File.write(file_path, "not a directory")
+				
 				expect do
 					subject.exclusive_unix(temporary_directory, unique: false)
 				end.to raise_exception(ArgumentError)
@@ -357,6 +360,10 @@ describe IO::Endpoint do
 				expect do
 					subject.exclusive_unix(File.join(temporary_directory, "missing"), unique: "worker")
 				end.to raise_exception(Errno::ENOENT)
+				
+				expect do
+					subject.exclusive_unix(file_path, unique: "worker")
+				end.to raise_exception(Errno::ENOTDIR)
 			end
 		end
 	end

--- a/test/io/endpoint/unix_endpoint.rb
+++ b/test/io/endpoint/unix_endpoint.rb
@@ -5,6 +5,7 @@
 # Copyright, 2026, by Delton Ding.
 
 require "io/endpoint/unix_endpoint"
+require "io/endpoint/exclusive_unix_endpoint"
 require "with_temporary_directory"
 require "sus/fixtures/async/reactor_context"
 require "async/variable"
@@ -21,6 +22,16 @@ describe IO::Endpoint::UNIXEndpoint do
 		endpoint.bind do |socket|
 			expect(socket).to be_a(Socket)
 		end
+	end
+	
+	it "does not remove the path when a bound endpoint closes" do
+		bound_endpoint = endpoint.bound
+		
+		expect(File).to be(:socket?, path)
+		bound_endpoint.close
+		expect(File).to be(:socket?, path)
+	ensure
+		bound_endpoint&.close
 	end
 	
 	it "can connect to address" do
@@ -107,6 +118,160 @@ describe IO::Endpoint::UNIXEndpoint do
 	end
 end
 
+describe IO::Endpoint::ExclusiveUNIXEndpoint do
+	include WithTemporaryDirectory
+	
+	let(:path) {File.join(temporary_directory, "test.ipc")}
+	let(:endpoint) {subject.new(path)}
+	
+	it "removes the path when the bound endpoint closes" do
+		bound_endpoint = endpoint.bound
+		lock_path = endpoint.address.unix_path + ".lock"
+		
+		expect(File).to be(:socket?, path)
+		expect(File).to be(:file?, lock_path)
+		bound_endpoint.close
+		expect(File).not.to be(:exist?, path)
+		expect(File).not.to be(:exist?, lock_path)
+	ensure
+		bound_endpoint&.close
+	end
+	
+	it "releases ownership when closing the socket raises" do
+		File.write(path, "owned")
+		lock = File.open(path + ".lock", File::RDWR | File::CREAT, 0o600)
+		ownership = subject::Ownership.new(lock, [path])
+		
+		socket = Class.new do
+			def close
+				raise IOError, "Could not close socket!"
+			end
+		end.new
+		
+		socket.instance_variable_set(:@exclusive_ownership, ownership)
+		socket.extend(subject::OwnedSocket)
+		
+		expect do
+			socket.close
+		end.to raise_exception(IOError, message: be == "Could not close socket!")
+		
+		expect(File).not.to be(:exist?, path)
+		expect(lock).to be(:closed?)
+	ensure
+		lock&.close unless lock&.closed?
+	end
+	
+	it "removes the path when a bind block completes" do
+		threads = endpoint.bind do |socket|
+			expect(socket).to be_a(Socket)
+		end
+		
+		threads.each(&:join)
+		expect(File).not.to be(:exist?, path)
+	end
+	
+	it "preserves ownership through a delegating endpoint" do
+		wrapper_class = Class.new(IO::Endpoint::Generic) do
+			def initialize(endpoint)
+				super()
+				@endpoint = endpoint
+			end
+			
+			def bind(...)
+				@endpoint.bind(...)
+			end
+		end
+		
+		bound_endpoint = wrapper_class.new(endpoint).bound
+		expect(File).to be(:socket?, path)
+		
+		bound_endpoint.close
+		expect(File).not.to be(:exist?, path)
+	ensure
+		bound_endpoint&.close
+	end
+	
+	it "does not replace an active socket" do
+		bound_endpoint = endpoint.bound
+		
+		expect do
+			subject.new(path).bound
+		end.to raise_exception(Errno::EADDRINUSE)
+		
+		expect(File).to be(:socket?, path)
+	ensure
+		bound_endpoint&.close
+	end
+	
+	it "does not remove a replacement filesystem entry when closed" do
+		bound_endpoint = endpoint.bound
+		File.unlink(path)
+		File.write(path, "replacement")
+		
+		bound_endpoint.close
+		expect(File.read(path)).to be == "replacement"
+	ensure
+		bound_endpoint&.close
+	end
+	
+	it "does not remove a replacement lock file when closed" do
+		bound_endpoint = endpoint.bound
+		lock_path = endpoint.address.unix_path + ".lock"
+		File.unlink(lock_path)
+		File.write(lock_path, "replacement")
+		
+		bound_endpoint.close
+		expect(File.read(lock_path)).to be == "replacement"
+	ensure
+		bound_endpoint&.close
+	end
+	
+	it "recovers a stale socket left by a previous owner" do
+		stale_endpoint = IO::Endpoint::UNIXEndpoint.new(path).bound
+		stale_endpoint.close
+		
+		expect(File).to be(:socket?, path)
+		
+		bound_endpoint = endpoint.bound
+		expect(File).to be(:socket?, path)
+		
+		bound_endpoint.close
+		expect(File).not.to be(:exist?, path)
+	ensure
+		stale_endpoint&.close
+		bound_endpoint&.close
+	end
+	
+	it "does not replace an unrelated filesystem entry" do
+		File.write(path, "important")
+		
+		expect do
+			endpoint.bound
+		end.to raise_exception(Errno::EADDRINUSE)
+		
+		expect(File.read(path)).to be == "important"
+	end
+	
+	with "a long path" do
+		let(:path) {File.join(temporary_directory, "a" * 140, "test.ipc")}
+		
+		it "removes both paths when closed" do
+			bound_endpoint = endpoint.bound
+			target_path = endpoint.address.unix_path
+			
+			expect(File).to be(:symlink?, path)
+			expect(File).to be(:socket?, target_path)
+			
+			bound_endpoint.close
+			
+			expect(File).not.to be(:symlink?, path)
+			expect(File).not.to be(:exist?, target_path)
+		ensure
+			bound_endpoint&.close
+		end
+	end
+end
+
 describe IO::Endpoint do
 	let(:endpoint) {subject.unix("/tmp/test.ipc", Socket::SOCK_DGRAM)}
 	
@@ -140,6 +305,58 @@ describe IO::Endpoint do
 				end
 				
 				server_task.wait
+			end
+		end
+	end
+	
+	with ".exclusive_unix" do
+		it "constructs an exclusive UNIX endpoint" do
+			endpoint = subject.exclusive_unix("/tmp/test.ipc")
+			
+			expect(endpoint).to be_a(IO::Endpoint::ExclusiveUNIXEndpoint)
+			expect(endpoint).to have_attributes(path: be == "/tmp/test.ipc")
+		end
+		
+		with "a unique prefix" do
+			include WithTemporaryDirectory
+			
+			it "constructs distinct endpoints within an existing directory" do
+				first = subject.exclusive_unix(temporary_directory, unique: "worker")
+				second = subject.exclusive_unix(temporary_directory, unique: "worker")
+				
+				expect(File.dirname(first.path)).to be == temporary_directory
+				expect(File.basename(first.path)).to be =~ /\Aworker-#{Process.pid}-[0-9a-f]{16}\.ipc\z/
+				expect(second.path).not.to be == first.path
+			end
+			
+			it "binds and removes the generated socket and lock paths" do
+				endpoint = subject.exclusive_unix(temporary_directory, unique: "worker")
+				bound_endpoint = endpoint.bound
+				lock_path = endpoint.address.unix_path + ".lock"
+				
+				expect(File).to be(:socket?, endpoint.path)
+				expect(File).to be(:file?, lock_path)
+				
+				bound_endpoint.close
+				
+				expect(File).not.to be(:exist?, endpoint.path)
+				expect(File).not.to be(:exist?, lock_path)
+			ensure
+				bound_endpoint&.close
+			end
+			
+			it "requires a valid prefix and an existing directory" do
+				expect do
+					subject.exclusive_unix(temporary_directory, unique: false)
+				end.to raise_exception(ArgumentError)
+				
+				expect do
+					subject.exclusive_unix(temporary_directory, unique: "worker/nested")
+				end.to raise_exception(ArgumentError)
+				
+				expect do
+					subject.exclusive_unix(File.join(temporary_directory, "missing"), unique: "worker")
+				end.to raise_exception(Errno::ENOENT)
 			end
 		end
 	end


### PR DESCRIPTION
## Summary

- Add `IO::Endpoint::ExclusiveUNIXEndpoint` as a dedicated subclass for UNIX socket path ownership.
- Add `IO::Endpoint.exclusive_unix(path)` as the explicit construction API; `IO::Endpoint.unix(path)` remains non-owning.
- Add `unique:` for generating an immediately inspectable worker socket path within an existing directory using a prefix, PID, and random entropy.
- Hold an adjacent `flock` for the socket lifetime so crashed workers release ownership automatically and later workers can recover stale sockets.
- Close the bound socket before releasing ownership, while guaranteeing cleanup if socket closure raises.
- Remove both the socket and lock paths on orderly close, with filesystem identity checks that preserve replacement entries.
- Preserve ownership cleanup through delegating endpoint wrappers such as `Async::HTTP::Endpoint`.
- Refuse to replace unrelated filesystem entries during stale socket recovery.

## Validation

- Full Sus suite: 75 passed, 164 assertions
- RuboCop: 39 files, no offenses
- Documentation coverage: 142/142 public definitions
- Verified recovery after `SIGKILL` for stable and generated socket paths
- Verified cleanup through `Async::HTTP::Endpoint`
- Verified ownership release when socket closure raises