### PR TITLE
Make UNIX endpoint connection test deterministic

### DIFF
--- a/test/io/endpoint/unix_endpoint.rb
+++ b/test/io/endpoint/unix_endpoint.rb
@@ -29,33 +29,30 @@ describe IO::Endpoint::UNIXEndpoint do
 		
 		expect(server).to be_a(Socket)
 		
-		server.listen(1)
-		
 		thread = Thread.new do
-			while true
-				peer, address = server.accept
-				peer.close
-			end
-		ensure
-			server&.close
+			accepted_socket, _address = server.accept
+			accepted_socket.close
 		end
-		
-		expect(endpoint).to be(:bound?)
-		
-		# Wait for the server to start accepting connections:
-		# I noticed on slow CI, that the connect would fail because the server has not called `#accept` yet, even if it's bound and listening!
-		Thread.pass until thread.status == "sleep"
 		
 		endpoint.connect do |socket|
 			expect(socket).to be_a(Socket)
 			
 			# Wait for the connection to be closed.
 			socket.wait_readable
-			
-			socket.close
 		end
+		
+		thread.value
 	ensure
+		sockets&.each(&:close)
 		thread&.kill
+		thread&.join
+	end
+	
+	it "can determine whether it is bound" do
+		sockets = endpoint.bind
+		
+		expect(endpoint).to be(:bound?)
+	ensure
 		sockets&.each(&:close)
 	end
 	


### PR DESCRIPTION
The UNIX endpoint connection test used `Thread#status` as a readiness signal after making a separate `bound?` probe connection. This allowed the actual connection attempt to race with the accept loop and intermittently fail with `ECONNREFUSED` on macOS.

Test exactly one accepted connection instead, propagate exceptions from the server thread, and cover `bound?` independently. `Endpoint#bind` already starts listening, so the additional `listen(1)` call is unnecessary.

Verification:
- 100 consecutive focused runs with Ruby 4.0
- Full test suite: 101 tests, 186 assertions
- RuboCop on the changed test file