### PR TITLE
Avoid matching platform-specific stream errors

### DIFF
--- a/test/io/endpoint/bound_endpoint.rb
+++ b/test/io/endpoint/bound_endpoint.rb
@@ -74,7 +74,7 @@ describe IO::Endpoint::BoundEndpoint do
 		
 		expect do
 			thread.join
-		end.to raise_exception(IOError, message: be =~ /stream closed in another thread/)
+		end.to raise_exception(IOError)
 	end
 	
 	with "timeouts" do


### PR DESCRIPTION
Closing a socket from another thread raises `IOError`, but MRI uses different messages across platforms: macOS can report `closed stream` while other runners report `stream closed in another thread`.

Assert the stable exception class instead of MRI implementation-specific wording.

Verification:
- 100 consecutive focused runs with Ruby 4.0
- Full test suite with Ruby 3.4 and Ruby 4.0
- RuboCop on the changed test file